### PR TITLE
ci: restore add-to-project.yaml workflow

### DIFF
--- a/.github/workflow/add-to-project.yaml
+++ b/.github/workflow/add-to-project.yaml
@@ -1,0 +1,20 @@
+name: Add Issues to Project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          # You can target a repository in a different organization
+          # to the issue
+          project-url: https://github.com/orgs/AFM-SPM/projects/2
+          github-token: ${{ secrets.GH_ISSUE_TO_PROJECT }}
+          labeled: admin, blocked, bug, CI/CD, DNATracing, documentation, enhancement, Filters, Grains, GrainStats, Images, linting, Plotting, testing, user experience
+          label-operator: OR


### PR DESCRIPTION
This was deleted by the :robot: that upgraded the Carpentries workflows so its being reinstated.